### PR TITLE
Support ctrl+hjkl in more apps and command history search

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Available commands:
 - `move_focus` with payload `up`, `down`, `left`, `right` to move the focus in the corresponding direction.
 - `move_focus_or_tab` with payload `up`, `down`, `left`, `right` to move the focus in the corresponding direction or switch to the next tab if the focus is already at the edge.
 - `resize` with payload `up`, `down`, `left`, `right` to resize the pane in the corresponding direction.
+- `enable`/`disable` or `toggle` as the payload to control if the plugin is active.
 
 If you use configuration for the plugin it must be added to every command in order to function consistently. 
 This is because the plugin is loaded with the configuration of the first command executed.
@@ -41,6 +42,8 @@ Available configuration options:
 - `move_mod`: The modifier key passed to Neovim with `move_focus` or `move_focus_or_tab`. Default: `ctrl`. Options: `ctrl`, `alt`.
 - `resize_mod`: The modifier key passed to Neovim with the `resize` command. Default: `alt`. Options: `ctrl`, `alt`.
 - `disable_for_apps`: The list of apps to automatically disable this plugin for so the shortcuts work as they would normally. Default: `"vim,nvim,fzf"`.
+
+Example keybindings:
 
 ```javascript
 keybinds {
@@ -121,3 +124,48 @@ keybinds {
 }
 ```
 
+If other applications use the same keybindings, like fzf in combination with Shell forward/backward command history search, you can configure these keybindings to first disable this plugin's keybindings and reenable them another keybindings was pressed. For example, press `Ctrl+r` to disable the plugin but still start command history search. Then on `ESC`/`Enter` or `Ctrl+c`, reenable the plugin again.
+
+```javascript
+keybindings {
+    shared_except "locked" {
+        bind "Ctrl r" { // Backward shell history
+            WriteChars "\u{0012}"; // Passthrough `Ctrl+r`
+            MessagePlugin "https://github.com/hiasr/vim-zellij-navigator/releases/download/0.2.1/vim-zellij-navigator.wasm" {
+                payload "disable";
+            };
+        }
+        bind "Ctrl s" { // Forward shell history
+            WriteChars "\u{0013}"; // Passthrough `Ctrl+s`
+            MessagePlugin "https://github.com/hiasr/vim-zellij-navigator/releases/download/0.2.1/vim-zellij-navigator.wasm" {
+                payload "disable";
+            };
+        }
+        bind "ESC" {
+            WriteChars "\u{001B}"; // Passthrough `ESC`
+            MessagePlugin "https://github.com/hiasr/vim-zellij-navigator/releases/download/0.2.1/vim-zellij-navigator.wasm" {
+                payload "enable";
+            };
+        }
+        bind "Enter" {
+            WriteChars "\u{000D}"; // Passthrough `Enter`
+            MessagePlugin "zellij-move" {
+                payload "enable";
+            };
+        }
+        bind "Ctrl c" {
+            WriteChars "\u{0003}"; // Passthrough `Ctrl+c`
+            MessagePlugin "https://github.com/hiasr/vim-zellij-navigator/releases/download/0.2.1/vim-zellij-navigator.wasm" {
+                payload "enable";
+            };
+        }
+
+        // Toggle the plugin on or off manually
+        bind "Ctrl Alt a" {
+            MessagePlugin "https://github.com/hiasr/vim-zellij-navigator/releases/download/0.2.1/vim-zellij-navigator.wasm" {
+                payload "toggle";
+            };
+        }
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is because the plugin is loaded with the configuration of the first command
 Available configuration options:
 - `move_mod`: The modifier key passed to Neovim with `move_focus` or `move_focus_or_tab`. Default: `ctrl`. Options: `ctrl`, `alt`.
 - `resize_mod`: The modifier key passed to Neovim with the `resize` command. Default: `alt`. Options: `ctrl`, `alt`.
+- `disable_for_apps`: The list of apps to automatically disable this plugin for so the shortcuts work as they would normally. Default: `"vim,nvim,fzf"`.
 
 ```javascript
 keybinds {


### PR DESCRIPTION
Hi there! Great plugin!

I ran into some issues with other apps like fzf no longer receiving ctrl-hjkl, and made some changes to make it work better with it. I couldn't figure out a way to detect when ctrl+r would show fzf in the current pane. I don't know if that's even possible. Instead, this solution supports toggling the plugin on and off and document keybinding config to make it work with those other apps.

﻿## Add config to disable plugin for more apps

When running fzf or other tools, it's nice if the plugin doesn't move panes or tabs when using the ctrl+h/j/k/l shortcuts, because those tools also use those shortcuts for navigation.

This change adds a configuration option to not switch panes or tabs when in the listed disabled apps, by default vim, nvim and fzf. People can add more apps if they need to.

## Add enable and disable messages

Allow people to control if the plugin is active or not. This can be helpful when the plugin needs to be temporarily disabled when an application uses the ctrl/alt+hjkl keybindings and you wouldn't want the plugin to switch pane or tab.

Updated the README with an example use case I ran into myself.
